### PR TITLE
Parse and provide reason for a xcarchive job failure

### DIFF
--- a/__test__/fixtures/xcarchive-fail.txt
+++ b/__test__/fixtures/xcarchive-fail.txt
@@ -1,0 +1,5 @@
+xcodebuild           -exportArchive           -archivePath "/tmp/qq2caLVF37/secure-image-20181126/SecureImage 2018-11-23, 5.26 PM.xcarchive"           -exportPath "/tmp/qq2caLVF37/signed/SecureImage_2018-11-23,_5"            -exportOptionsPlist /tmp/qq2caLVF37/secure-image-20181126/options.plist 
+
+error: Couldn't load -exportOptionsPlist: The file “options.plist” couldn’t be opened because there is no such file.
+
+Error Domain=NSCocoaErrorDomain Code=260 "The file “options.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/tmp/qq2caLVF37/secure-image-20181126/options.plist, NSUnderlyingError=0x7fe8b7a7be00 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}

--- a/__test__/sign.spec.js
+++ b/__test__/sign.spec.js
@@ -1,0 +1,39 @@
+//
+// SecureImage
+//
+// Copyright © 2018 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Created by Jason Leach on 2018-01-10.
+//
+
+/* eslint-env es6 */
+
+'use strict';
+
+import fs from 'fs';
+import path from 'path';
+import { parseXcodebuildError } from '../src/libs/sign';
+
+const p0 = path.join(__dirname, 'fixtures/xcarchive-fail.txt');
+const xcodeBuildError = fs.readFileSync(p0, 'utf8');
+
+describe('Signing helper functions', () => {
+  test('An xcode build error is correctly parsed', async () => {
+    const aResponse = `Couldn't load -exportOptionsPlist: The file “options.plist” couldn’t be opened because there is no such file.`;
+    const message = parseXcodebuildError(xcodeBuildError);
+
+    expect(message).toBe(aResponse);
+  });
+});

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -229,7 +229,13 @@ const getKeyStore = async apkBundleID => {
   return fetchKeychainValue(keystoreKeys, apkBundleID);
 };
 
-const parseXcodebuildError = message => {
+/**
+ * Parse out the meaningful error message from a failed xcode build message
+ *
+ * @param {string} message Multiline message from xcode build
+ * @returns A `string` containing the meaningful error message
+ */
+export const parseXcodebuildError = message => {
   const key = 'error:';
   const aLine = message.split('\n').find(line => line.startsWith(key));
 

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -172,7 +172,9 @@ const getApkBundleID = async apkPackage => {
  * @param {Object} keystoreKeys The keywords for keystore pair
  */
 const createKeyStore = async (keystoreKeys, apkBundleID) => {
-  const keystorePassword = Math.random().toString(36).substring(7);
+  const keystorePassword = Math.random()
+    .toString(36)
+    .substring(7);
 
   try {
     // 1. create keystore:
@@ -192,11 +194,13 @@ const createKeyStore = async (keystoreKeys, apkBundleID) => {
     }
 
     // 2. Save into keychain:
+    /* eslint-disable */
     await exec(`
       security add-generic-password -a ${apkBundleID} -s ${keystoreKeys[0]} -p ${apkBundleID} -T /usr/bin/security -U
       security add-generic-password -a ${apkBundleID} -s ${keystoreKeys[1]} -p ${keystorePassword} -T /usr/bin/security -U
       security add-generic-password -a ${apkBundleID} -s ${keystoreKeys[2]} -p "$(pwd)"/${apkBundleID}-ks.jks -T /usr/bin/security -U
     `);
+    /* eslint-enable */
   } catch (err) {
     throw new Error(`Unable to generate and save keystore for this app: ${err}`);
   }
@@ -223,6 +227,13 @@ const getKeyStore = async apkBundleID => {
   }
 
   return fetchKeychainValue(keystoreKeys, apkBundleID);
+};
+
+const parseXcodebuildError = message => {
+  const key = 'error:';
+  const aLine = message.split('\n').find(line => line.startsWith(key));
+
+  return aLine.substr(key.length).trim();
 };
 
 /**
@@ -280,8 +291,11 @@ export const signxcarchive = async (archiveFilePath, workspace = '/tmp/') => {
 
     return packageForDelivery(path.join(apath, outputDir), items);
   } catch (err) {
-    logger.error(err.message);
-    throw err;
+    const errorMessage = parseXcodebuildError(err.message);
+    const message = 'Unable to sign xcarchive';
+    logger.error(`${message}, err = ${err.message}`);
+
+    throw new Error(errorMessage);
   }
 };
 

--- a/src/router/routes/job.js
+++ b/src/router/routes/job.js
@@ -246,14 +246,6 @@ router.post(
     } catch (signErr) {
       const signMessage = 'Unable to sign job';
       logger.error(`${signMessage}, err = ${signErr.message}`);
-
-      await reportJobStatus({
-        ...job,
-        ...{
-          status: JOB_STATUS.FAILED,
-          message: signErr.message,
-        },
-      });
     }
   })
 );

--- a/src/router/routes/job.js
+++ b/src/router/routes/job.js
@@ -247,8 +247,16 @@ router.post(
       // result is the updated job object:
       const result = await handleJob(job);
       await reportJobStatus(result);
-    } catch (err) {
-      throw err;
+    } catch (signErr) {
+      const signMessage = 'Unable to sign job';
+      logger.error(`${signMessage}, err = ${signErr.message}`);
+
+      try {
+        await reportJobStatus({ ...job, ...{ status: JOB_STATUS.FAILED } });
+      } catch (reportErr) {
+        const reportMessage = 'Unable to report job status';
+        logger.error(`${reportMessage}, err = ${reportErr.message}`);
+      }
     }
   })
 );


### PR DESCRIPTION
When an iOS (xcarchive) signing job fails the error message is parsed out and sent back with the status report.