### PR TITLE
Parse meaningful message from apksigner error

### DIFF
--- a/__test__/fixtures/apksigner-fai-no-file.txt
+++ b/__test__/fixtures/apksigner-fai-no-file.txt
@@ -1,0 +1,7 @@
+Exception in thread "main" java.io.FileNotFoundException: ./app.apk (No such file or directory)
+        at java.io.RandomAccessFile.open0(Native Method)
+        at java.io.RandomAccessFile.open(RandomAccessFile.java:316)
+        at java.io.RandomAccessFile.<init>(RandomAccessFile.java:243)
+        at com.android.apksig.ApkSigner.sign(ApkSigner.java:166)
+        at com.android.apksigner.ApkSignerTool.sign(ApkSignerTool.java:330)
+        at com.android.apksigner.ApkSignerTool.main(ApkSignerTool.java:89)

--- a/__test__/fixtures/apksigner-fail-no-key.txt
+++ b/__test__/fixtures/apksigner-fail-no-key.txt
@@ -1,0 +1,1 @@
+Failed to load signer "signer #1": ./ca.bc.gov.appKey.jks entry "ca.bc.gov.appKey" does not contain a key

--- a/__test__/fixtures/apksigner-fail.txt
+++ b/__test__/fixtures/apksigner-fail.txt
@@ -1,0 +1,16 @@
+Failed to load signer "signer #1"
+java.io.IOException: Keystore was tampered with, or password was incorrect
+        at sun.security.provider.JavaKeyStore.engineLoad(JavaKeyStore.java:780)
+        at sun.security.provider.JavaKeyStore$JKS.engineLoad(JavaKeyStore.java:56)
+        at sun.security.provider.KeyStoreDelegator.engineLoad(KeyStoreDelegator.java:224)
+        at sun.security.provider.JavaKeyStore$DualFormatJKS.engineLoad(JavaKeyStore.java:70)
+        at java.security.KeyStore.load(KeyStore.java:1445)
+        at com.android.apksigner.ApkSignerTool$SignerParams.loadKeyStoreFromFile(ApkSignerTool.java:833)
+        at com.android.apksigner.ApkSignerTool$SignerParams.loadPrivateKeyAndCertsFromKeyStore(ApkSignerTool.java:723)
+        at com.android.apksigner.ApkSignerTool$SignerParams.loadPrivateKeyAndCerts(ApkSignerTool.java:663)
+        at com.android.apksigner.ApkSignerTool$SignerParams.access$500(ApkSignerTool.java:615)
+        at com.android.apksigner.ApkSignerTool.sign(ApkSignerTool.java:269)
+        at com.android.apksigner.ApkSignerTool.main(ApkSignerTool.java:89)
+Caused by: java.security.UnrecoverableKeyException: Password verification failed
+        at sun.security.provider.JavaKeyStore.engineLoad(JavaKeyStore.java:778)
+        ... 10 more

--- a/__test__/fixtures/apksigner-paser-fail.txt
+++ b/__test__/fixtures/apksigner-paser-fail.txt
@@ -1,0 +1,1 @@
+Failed to load signer "signer #1"

--- a/__test__/sign.spec.js
+++ b/__test__/sign.spec.js
@@ -24,7 +24,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { parseXcodebuildError } from '../src/libs/sign';
+import { parseXcodebuildError, parseApksignerbuildError } from '../src/libs/sign';
 
 const p0 = path.join(__dirname, 'fixtures/xcarchive-fail.txt');
 const xcodeBuildError = fs.readFileSync(p0, 'utf8');
@@ -35,5 +35,41 @@ describe('Signing helper functions', () => {
     const message = parseXcodebuildError(xcodeBuildError);
 
     expect(message).toBe(aResponse);
+  });
+
+  test('An apksigner build error is correctly parsed', async () => {
+    const signerFailErr = 'Keystore was tampered with, or password was incorrect';
+    const errorPath = path.join(__dirname, 'fixtures/apksigner-fail.txt');
+    const apksignerError = fs.readFileSync(errorPath, 'utf8');
+    const signerFailMsg = parseApksignerbuildError(apksignerError);
+
+    expect(signerFailMsg).toBe(signerFailErr);
+  });
+
+  test('An apksigner file-not-found error is correctly parsed', async () => {
+    const noFileErr = './app.apk (No such file or directory)';
+    const errorPath = path.join(__dirname, 'fixtures/apksigner-fai-no-file.txt');
+    const apksignerError = fs.readFileSync(errorPath, 'utf8');
+    const noFileMsg = parseApksignerbuildError(apksignerError);
+
+    expect(noFileMsg).toBe(noFileErr);
+  });
+
+  test('An apksigner wrong-key error is correctly parsed', async () => {
+    const noKeyErr = `./ca.bc.gov.appKey.jks entry "ca.bc.gov.appKey" does not contain a key`;
+    const errorPath = path.join(__dirname, 'fixtures/apksigner-fail-no-key.txt');
+    const apksignerError = fs.readFileSync(errorPath, 'utf8');
+    const noKeyMsg = parseApksignerbuildError(apksignerError);
+
+    expect(noKeyMsg).toBe(noKeyErr);
+  });
+
+  test('An apksigner error paser failure is correctly parsed', async () => {
+    const parserErr = `APK error is not read properly. Update error message paser, err = Cannot read property 'split' of undefined`;
+    const errorPath = path.join(__dirname, 'fixtures/apksigner-paser-fail.txt');
+    const apksignerParserError = fs.readFileSync(errorPath, 'utf8');
+    const parserMsg = parseApksignerbuildError(apksignerParserError);
+
+    expect(parserMsg).toBe(parserErr);
   });
 });

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -251,7 +251,7 @@ export const parseXcodebuildError = message => {
 export const parseApksignerbuildError = message => {
   const key = ':';
   try {
-    const aLine = message.split(`${key}`)[1].split('\n')[0];
+    const aLine = message.split(key)[1].split('\n')[0];
     return aLine.substr(key.length).trim();
   } catch (err) {
     const hint = 'APK error is not read properly. Update error message paser';

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -243,6 +243,19 @@ export const parseXcodebuildError = message => {
 };
 
 /**
+ * Parse out the meaningful error message from a failed apksigner sign job
+ *
+ * @param {string} message Multiline message from apksigner build
+ * @returns A `string` containing the meaningful error message
+ */
+export const parseApksignerbuildError = message => {
+  const key = ':';
+  const aLine = message.split(`${key}`)[1].split('\n')[0];
+
+  return aLine.substr(key.length).trim();
+};
+
+/**
  * Sign an xcode xcarchive file.
  *
  * @param {string} archiveFilePath The path to the xcarchive file
@@ -361,43 +374,51 @@ export const signipaarchive = async (archiveFilePath, workspace = '/tmp/') => {
 // eslint-disable-next-line no-unused-vars
 /* eslint-disable global-require */
 export const signapkarchive = async (archiveFilePath, workspace = '/tmp/') => {
-  const apath = path.join(workspace, shortid.generate());
-  const packagePath = path.join(apath, shortid.generate());
-  const outFileName = `${path.join(packagePath, shortid.generate())}.apk`;
-  const keystoreKeys = ['keyAlias', 'keyPassword', 'keyStorePath'];
+  try {
+    const apath = path.join(workspace, shortid.generate());
+    const packagePath = path.join(apath, shortid.generate());
+    const outFileName = `${path.join(packagePath, shortid.generate())}.apk`;
+    const keystoreKeys = ['keyAlias', 'keyPassword', 'keyStorePath'];
 
-  // Get the package from minio:
-  const buffer = await getObject(shared.minio, bucket, archiveFilePath);
-  await exec(`mkdir -p ${packagePath}`);
-  await writeFile(outFileName, buffer, 'utf8');
+    // Get the package from minio:
+    const buffer = await getObject(shared.minio, bucket, archiveFilePath);
+    await exec(`mkdir -p ${packagePath}`);
+    await writeFile(outFileName, buffer, 'utf8');
 
-  // Get the path of package locally:
-  const apkPathFull = await exec(`find ${packagePath} -iname '*.apk'`);
-  if (apkPathFull.stderr) {
-    throw new Error('Cannot find the package.');
+    // Get the path of package locally:
+    const apkPathFull = await exec(`find ${packagePath} -iname '*.apk'`);
+    if (apkPathFull.stderr) {
+      throw new Error('Cannot find the package.');
+    }
+    const apkPath = apkPathFull.stdout.trim().split('\n');
+
+    // Fetch signing keystore, key alias and password from keyChain:
+    const apkBundleID = await getApkBundleID(apkPath);
+    const keystorePairs = await getKeyStore(apkBundleID);
+
+    // Sign the apk:
+    const response = await exec(`
+      apksigner sign \
+      -v \
+      --ks ${keystorePairs[keystoreKeys[2]]} \
+      --ks-key-alias ${keystorePairs[keystoreKeys[0]]} \
+      --ks-pass pass:${keystorePairs[keystoreKeys[1]]} \
+      --key-pass pass:${keystorePairs[keystoreKeys[1]]} \
+      --out ${outFileName} \
+      ${apkPath}`);
+
+    if (!response.stdout.includes('Signed')) {
+      throw new Error(response.stderr);
+    }
+
+    logger.info('Successfully signed package.');
+
+    return outFileName;
+  } catch (err) {
+    const errorMessage = parseApksignerbuildError(err.message);
+    const message = 'Unable to sign apk';
+    logger.error(`${message}, err = ${err.message}`);
+
+    throw new Error(errorMessage);
   }
-  const apkPath = apkPathFull.stdout.trim().split('\n');
-
-  // Fetch signing keystore, key alias and password from keyChain:
-  const apkBundleID = await getApkBundleID(apkPath);
-  const keystorePairs = await getKeyStore(apkBundleID);
-
-  // Sign the apk:
-  const response = await exec(`
-    apksigner sign \
-    -v \
-    --ks ${keystorePairs[keystoreKeys[2]]} \
-    --ks-key-alias ${keystorePairs[keystoreKeys[0]]} \
-    --ks-pass pass:${keystorePairs[keystoreKeys[1]]} \
-    --key-pass pass:${keystorePairs[keystoreKeys[1]]} \
-    --out ${outFileName} \
-    ${apkPath}`);
-
-  if (!response.stdout.includes('Signed')) {
-    throw new Error(response.stderr);
-  }
-
-  logger.info('Successfully signed package.');
-
-  return outFileName;
 };

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -250,9 +250,13 @@ export const parseXcodebuildError = message => {
  */
 export const parseApksignerbuildError = message => {
   const key = ':';
-  const aLine = message.split(`${key}`)[1].split('\n')[0];
-
-  return aLine.substr(key.length).trim();
+  try {
+    const aLine = message.split(`${key}`)[1].split('\n')[0];
+    return aLine.substr(key.length).trim();
+  } catch (err) {
+    const hint = 'APK error is not read properly. Update error message paser';
+    return `${hint}, err = ${err.message}`;
+  }
 };
 
 /**

--- a/src/router/routes/job.js
+++ b/src/router/routes/job.js
@@ -168,7 +168,7 @@ const handleJob = async (job, clean = true) => {
       ...{ deliveryFileName: filename, deliveryFileEtag: etag, status: JOB_STATUS.COMPLETED },
     };
   } catch (error) {
-    const message = 'Unable to sign archive';
+    const message = 'Signing job not successful';
     logger.error(`${message}, err = ${error.message}`);
     // Instead of throwing an error, return a job object with error message:
     return {


### PR DESCRIPTION
When an apk signing job fails the error message is parsed out and sent back with the status report.