### PR TITLE
Add quotes to options file

### DIFF
--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -292,7 +292,7 @@ export const signxcarchive = async (archiveFilePath, workspace = '/tmp/') => {
           -exportArchive \
           -archivePath "${element}" \
           -exportPath "${exppath}"  \
-          -exportOptionsPlist ${path.join(path.dirname(element), 'options.plist')} 
+          -exportOptionsPlist "${path.join(path.dirname(element), 'options.plist')}"
         `);
       });
 


### PR DESCRIPTION
The options file needs quotes around in case the file path has spaces in it. Without quotes, spaces will cause the signing job to not find the `options.plist` file and fail.