### PR TITLE
Fix: patrial signing code not updated

### DIFF
--- a/scripts/mkc.sh
+++ b/scripts/mkc.sh
@@ -5,17 +5,16 @@ CERT_PATH=/Users/xcode/certificates.p12
 
 echo "Keychain Starting"
 
-# Code 0 = Ok
-# Code 1 = Locked
-# Code 36 = Locked
-# Code 50 = Not Found
-/usr/bin/security show-keychain-info $KC_NAME 2>/dev/null
+# check if target keychain exists:
+/usr/bin/security list-keychains -d user | grep $KC_NAME &> /dev/null
 rv=$?
 
-if [ $rv -eq 0 ]; then
-  /usr/bin/security list-keychains -d user -s $KC_NAME
-  echo "Keychain ready"
-elif [ $rv -eq 50 ]; then
+if [[ $rv == 0 ]]; then
+  # unlock keychain as it's always locked after reboot:
+  echo "Unlocking keychain"
+  /usr/bin/security unlock-keychain -p $1 $KC_NAME
+  /usr/bin/security show-keychain-info $KC_NAME
+else
   echo "Building keychian"
   /usr/bin/security create-keychain -p $1 $KC_NAME
   /usr/bin/security unlock-keychain -p $1 $KC_NAME
@@ -23,13 +22,6 @@ elif [ $rv -eq 50 ]; then
   /usr/bin/security import $CERT_PATH -k $KC_NAME -P $1 -T /usr/bin/codesign
   /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $1 $KC_NAME
   /usr/bin/security set-keychain-settings $KC_NAME
-elif [ $rv -eq 1 ] || [ $rv -eq 36 ] ; then
-  echo "Unlocking keychain"
-  /usr/bin/security unlock-keychain -p $1 $KC_NAME
-  /usr/bin/security show-keychain-info $KC_NAME
-else
-  echo "Unable to process keychain, error = $rv"
-  exit 1
 fi
 
 echo "Keychain Finished"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,7 +14,7 @@ sleep 5
 
 if [ $? -eq 0 ]; then
   echo "Checking for updates"
-  if [ $(git status -uno | grep "Your branch is up to date") ] ||
+  if [ $(git status -uno | grep -q "Your branch is up to date") ] ||
   [ ! -d build ]; then
     echo "Fetching updates and rebuilding"
     git pull && \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,14 +14,13 @@ sleep 5
 
 if [ $? -eq 0 ]; then
   echo "Checking for updates"
-  if [ $(git status -uno | grep -q "Your branch is up to date") ] ||
-  [ ! -d build ]; then
+  if $(git status -uno | grep -q "Your branch is up to date"); then
+    echo "Clean up build folder and previously installed dependencies..."
+    rm -rf build/ node_modules/
     echo "Fetching updates and rebuilding"
     git pull && \
-    npm run build && \
-    pushd build && \
-    npm i --prod-only && \
-    popd
+    npm i && \
+    npm run build 
   fi
 
   echo "Starting Agent"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,7 +14,7 @@ sleep 5
 
 if [ $? -eq 0 ]; then
   echo "Checking for updates"
-  if [ $(git status -uno | grep -q "Your branch is up to date") ] ||
+  if [ $(git status -uno | grep "Your branch is up to date") ] ||
   [ ! -d build ]; then
     echo "Fetching updates and rebuilding"
     git pull && \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,7 +14,7 @@ sleep 5
 
 if [ $? -eq 0 ]; then
   echo "Checking for updates"
-  if $(git status -uno | grep -q "Your branch is up to date"); then
+  if [ $(git status -uno | grep -q "Your branch is up to date") ] || [ ! -d ../build ]; then
     echo "Clean up build folder and previously installed dependencies..."
     rm -rf build/ node_modules/
     echo "Fetching updates and rebuilding"

--- a/src/libs/deploy.js
+++ b/src/libs/deploy.js
@@ -157,9 +157,7 @@ export const deployToGooglePlayStore = async (signedApp, workspace = '/tmp/') =>
     const signedAPK = await readFile(signedApkPath);
     // Get the Google client-service key to deployment:
     const keyFull = await exec(
-      `security find-generic-password -w -s deployKey -a ${apkBundleId} ${
-        LOCAL_PATHS.KEYCHAIN_NAME
-      }`
+      `security find-generic-password -w -s deployKey -a ${apkBundleId}`
     );
     const keyPath = keyFull.stdout.trim().split('\n');
     const key = JSON.parse(await readFile(keyPath));

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -161,6 +161,7 @@ const getApkBundleID = async apkPackage => {
     cut -d "'" -f2
     `);
     // Get rid of the linebreak at the end:
+    logger.info(apkBundle.stdout);
     return apkBundle.stdout.replace(/(\r\n\t|\n|\r\t)/gm, '');
   } catch (error) {
     throw new Error(`Unable to find package name! ${error}`);
@@ -217,7 +218,8 @@ const getKeyStore = async apkBundleID => {
 
   // 1. Use security to check for android keystore in keychain:
   try {
-    await exec(`security find-generic-password -w -a ${apkBundleID} ${LOCAL_PATHS.KEYCHAIN_NAME}`);
+    await exec(`security find-generic-password -w -a ${apkBundleID}`);
+    // await exec(`security find-generic-password -w -a ${apkBundleID} ${LOCAL_PATHS.KEYCHAIN_NAME}`);
   } catch (err) {
     logger.info(`No keystore for this app...start to create new for ${apkBundleID}:`);
 

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -219,7 +219,6 @@ const getKeyStore = async apkBundleID => {
   // 1. Use security to check for android keystore in keychain:
   try {
     await exec(`security find-generic-password -w -a ${apkBundleID}`);
-    // await exec(`security find-generic-password -w -a ${apkBundleID} ${LOCAL_PATHS.KEYCHAIN_NAME}`);
   } catch (err) {
     logger.info(`No keystore for this app...start to create new for ${apkBundleID}:`);
 

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -161,7 +161,7 @@ const getApkBundleID = async apkPackage => {
     cut -d "'" -f2
     `);
     // Get rid of the linebreak at the end:
-    logger.info(apkBundle.stdout);
+    logger.info(`Package bundle id ${apkBundle.stdout}`);
     return apkBundle.stdout.replace(/(\r\n\t|\n|\r\t)/gm, '');
   } catch (error) {
     throw new Error(`Unable to find package name! ${error}`);


### PR DESCRIPTION
## background:
looking into the issue where some code was not updated.

## Issues:
- start.sh not rebuilding after each restart
- keychain not unlocked successfully
- security command has been updated recently that no need to pass in keychain name when finding a key

## fix:
- remove build and node_modules folders during each restart, always do `npm i` before npm build
- update mkc.sh to unlock keychain
- update search query for keychains
