### PR TITLE
Fix: android command tools issue

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,14 @@
+NODE_ENV=development
+PORT=
+KEYCHAIN_PWD=
+
+# Production PATH
+AAPT_PATH=<absolute path for command tools>
+
+# OpenShift
+MINIO_ACCESS_KEY=
+MINIO_SECRET_KEY=
+MINIO_HOST=
+
+# SSO
+SSO_CLIENT_SECRET=

--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,7 @@ PORT=
 KEYCHAIN_PWD=
 
 # Production PATH
-AAPT_PATH=<absolute path for command tools>
+ANDROID_SDK_PATH=<absolute path for command tools>
 
 # OpenShift
 MINIO_ACCESS_KEY=

--- a/README.md
+++ b/README.md
@@ -53,19 +53,15 @@ oc create -f -
 
 See the [API documentation](https://github.com/bcdevops/mobile-cicd-api.git/README.md) on how to setup and run supplemental services like minio.
 
-Create an `.env` file on the root folder with the following variables:
-
-```console
-NODE_ENV=development
-MINIO_ACCESS_KEY="XXXXXXXX"
-MINIO_SECRET_KEY="YYYYYYYYYYYYYYYY"
-MINIO_HOST="localhost"
-PORT=8089
-```
+Create an `.env` file on the root folder based on the template `.env.sample`.
 
 Run the node application with the following command:
 
-```console
+```shell
+# Create an `.env` file on the root folder based on template
+cp .env.sample .env
+
+# Run
 npm run dev
 ```
 

--- a/scripts/mkc.sh
+++ b/scripts/mkc.sh
@@ -5,17 +5,16 @@ CERT_PATH=/Users/xcode/certificates.p12
 
 echo "Keychain Starting"
 
-# Code 0 = Ok
-# Code 1 = Locked
-# Code 36 = Locked
-# Code 50 = Not Found
-/usr/bin/security show-keychain-info $KC_NAME 2>/dev/null
+# check if target keychain exists:
+/usr/bin/security list-keychains -d user | grep $KC_NAME &> /dev/null
 rv=$?
 
-if [ $rv -eq 0 ]; then
-  /usr/bin/security list-keychains -d user -s $KC_NAME
-  echo "Keychain ready"
-elif [ $rv -eq 50 ]; then
+if [[ $rv == 0 ]]; then
+  # unlock keychain as it's always locked after reboot:
+  echo "Unlocking keychain"
+  /usr/bin/security unlock-keychain -p $1 $KC_NAME
+  /usr/bin/security show-keychain-info $KC_NAME
+else
   echo "Building keychian"
   /usr/bin/security create-keychain -p $1 $KC_NAME
   /usr/bin/security unlock-keychain -p $1 $KC_NAME
@@ -23,13 +22,6 @@ elif [ $rv -eq 50 ]; then
   /usr/bin/security import $CERT_PATH -k $KC_NAME -P $1 -T /usr/bin/codesign
   /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $1 $KC_NAME
   /usr/bin/security set-keychain-settings $KC_NAME
-elif [ $rv -eq 1 ] || [ $rv -eq 36 ] ; then
-  echo "Unlocking keychain"
-  /usr/bin/security unlock-keychain -p $1 $KC_NAME
-  /usr/bin/security show-keychain-info $KC_NAME
-else
-  echo "Unable to process keychain, error = $rv"
-  exit 1
 fi
 
 echo "Keychain Finished"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,7 +14,7 @@ sleep 5
 
 if [ $? -eq 0 ]; then
   echo "Checking for updates"
-  if [ $(git status -uno | grep "Your branch is up to date") ] ||
+  if [ $(git status -uno | grep -q "Your branch is up to date") ] ||
   [ ! -d build ]; then
     echo "Fetching updates and rebuilding"
     git pull && \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,14 +14,13 @@ sleep 5
 
 if [ $? -eq 0 ]; then
   echo "Checking for updates"
-  if [ $(git status -uno | grep -q "Your branch is up to date") ] ||
-  [ ! -d build ]; then
+  if $(git status -uno | grep -q "Your branch is up to date"); then
+    echo "Clean up build folder and previously installed dependencies..."
+    rm -rf build/ node_modules/
     echo "Fetching updates and rebuilding"
     git pull && \
-    npm run build && \
-    pushd build && \
-    npm i --prod-only && \
-    popd
+    npm i && \
+    npm run build 
   fi
 
   echo "Starting Agent"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,7 +14,7 @@ sleep 5
 
 if [ $? -eq 0 ]; then
   echo "Checking for updates"
-  if [ $(git status -uno | grep -q "Your branch is up to date") ] ||
+  if [ $(git status -uno | grep "Your branch is up to date") ] ||
   [ ! -d build ]; then
     echo "Fetching updates and rebuilding"
     git pull && \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,7 +14,7 @@ sleep 5
 
 if [ $? -eq 0 ]; then
   echo "Checking for updates"
-  if $(git status -uno | grep -q "Your branch is up to date"); then
+  if [ $(git status -uno | grep -q "Your branch is up to date") ] || [ ! -d ../build ]; then
     echo "Clean up build folder and previously installed dependencies..."
     rm -rf build/ node_modules/
     echo "Fetching updates and rebuilding"

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -44,6 +44,9 @@ nconf.overrides({
   environment: env,
   host: process.env.HOST || '127.0.0.1',
   port: process.env.PORT || defaultPort,
+  tools: {
+    aapt: process.env.AAPT_PATH || 'aapt',
+  },
   minio: {
     host: process.env.MINIO_HOST,
     accessKey: process.env.MINIO_ACCESS_KEY,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -45,7 +45,9 @@ nconf.overrides({
   host: process.env.HOST || '127.0.0.1',
   port: process.env.PORT || defaultPort,
   tools: {
-    aapt: process.env.AAPT_PATH || 'aapt',
+    sdk: process.env.ANDROID_SDK_PATH || '$ANDROID_HOME',
+    aapt: path.join(process.env.ANDROID_SDK_PATH, 'aapt'),
+    apksigner: path.join(process.env.ANDROID_SDK_PATH, 'apksigner'),
   },
   minio: {
     host: process.env.MINIO_HOST,

--- a/src/libs/deploy.js
+++ b/src/libs/deploy.js
@@ -157,9 +157,7 @@ export const deployToGooglePlayStore = async (signedApp, workspace = '/tmp/') =>
     const signedAPK = await readFile(signedApkPath);
     // Get the Google client-service key to deployment:
     const keyFull = await exec(
-      `security find-generic-password -w -s deployKey -a ${apkBundleId} ${
-        LOCAL_PATHS.KEYCHAIN_NAME
-      }`
+      `security find-generic-password -w -s deployKey -a ${apkBundleId}`
     );
     const keyPath = keyFull.stdout.trim().split('\n');
     const key = JSON.parse(await readFile(keyPath));

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -409,7 +409,7 @@ export const signapkarchive = async (archiveFilePath, workspace = '/tmp/') => {
 
     // Sign the apk:
     const response = await exec(`
-      apksigner sign \
+      ${config.get('tools:apksigner')} sign \
       -v \
       --ks ${keystorePairs[keystoreKeys[2]]} \
       --ks-key-alias ${keystorePairs[keystoreKeys[0]]} \

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -161,6 +161,7 @@ const getApkBundleID = async apkPackage => {
     cut -d "'" -f2
     `);
     // Get rid of the linebreak at the end:
+    logger.info(apkBundle.stdout);
     return apkBundle.stdout.replace(/(\r\n\t|\n|\r\t)/gm, '');
   } catch (error) {
     throw new Error(`Unable to find package name! ${error}`);
@@ -217,7 +218,8 @@ const getKeyStore = async apkBundleID => {
 
   // 1. Use security to check for android keystore in keychain:
   try {
-    await exec(`security find-generic-password -w -a ${apkBundleID} ${LOCAL_PATHS.KEYCHAIN_NAME}`);
+    await exec(`security find-generic-password -w -a ${apkBundleID}`);
+    // await exec(`security find-generic-password -w -a ${apkBundleID} ${LOCAL_PATHS.KEYCHAIN_NAME}`);
   } catch (err) {
     logger.info(`No keystore for this app...start to create new for ${apkBundleID}:`);
 

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -219,7 +219,6 @@ const getKeyStore = async apkBundleID => {
   // 1. Use security to check for android keystore in keychain:
   try {
     await exec(`security find-generic-password -w -a ${apkBundleID}`);
-    // await exec(`security find-generic-password -w -a ${apkBundleID} ${LOCAL_PATHS.KEYCHAIN_NAME}`);
   } catch (err) {
     logger.info(`No keystore for this app...start to create new for ${apkBundleID}:`);
 

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -155,13 +155,15 @@ const packageForDelivery = async (apath, items) => {
 const getApkBundleID = async apkPackage => {
   try {
     // Use Android Asset Packaging Tool to get package bundle ID:
-    const apkBundle = await exec(`
-    aapt dump badging ${apkPackage} | \
-    grep package: | \
-    cut -d "'" -f2
-    `);
-    // Get rid of the linebreak at the end:
+    const apkBundle = await exec(
+      `${config.get('tools:aapt')} dump badging ${apkPackage} | grep "package" | cut -d "'" -f2`
+    );
     logger.info(`Package bundle id ${apkBundle.stdout}`);
+    if (!apkBundle.stdout) {
+      throw Error('No bundle ID found!');
+    }
+    logger.info(`Package bundle ID: ${apkBundle.stdout}`);
+    // Get rid of the linebreak at the end:
     return apkBundle.stdout.replace(/(\r\n\t|\n|\r\t)/gm, '');
   } catch (error) {
     throw new Error(`Unable to find package name! ${error}`);

--- a/src/libs/sign.js
+++ b/src/libs/sign.js
@@ -161,7 +161,7 @@ const getApkBundleID = async apkPackage => {
     cut -d "'" -f2
     `);
     // Get rid of the linebreak at the end:
-    logger.info(apkBundle.stdout);
+    logger.info(`Package bundle id ${apkBundle.stdout}`);
     return apkBundle.stdout.replace(/(\r\n\t|\n|\r\t)/gm, '');
   } catch (error) {
     throw new Error(`Unable to find package name! ${error}`);


### PR DESCRIPTION
## background:
Need to provide the path for Android command tools which is not available in default PATH. This is related to shell process difference in npm run and build. The local PATH are not included in build. Thus, directly calling the command tools does not work.

## Solve:
adding the path as part of the .env solve the problem.